### PR TITLE
Fix bug: Cannot find module 'react-for-atom'

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
   "dependencies": {
     "atom-space-pen-views": "^2.2.0",
     "axios": "^0.15.0",
-    "react-markdown": "^2.4.2"
+    "react-markdown": "^2.4.2",
+    "react-for-atom": "^15.3.1-0"
   },
   "devDependencies": {
     "react": "^15.3.2",
-    "react-dom": "^15.3.2",
-    "react-for-atom": "^15.3.1-0"
+    "react-dom": "^15.3.2"
   }
 }


### PR DESCRIPTION
`Cannot find module 'react-for-atom'`